### PR TITLE
Allow more than 3 passengers

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -119,7 +119,7 @@ end
 -- In code you control be sure to always use the newer API and to call this function on every change.
 -- If you would like to improove preformance (memory & CPU) by not updating the old API, set
 --  entity.dont_use_old_passenger_api to true. This will return from the funciton instead of doing anything.
-local function copy_a_passenger_to_old_api(entity,index,player,attach,eye)
+local function old_copy_passenger(entity,index,player,attach,eye)
 	if entity.dont_use_old_passenger_api then
 		return
 	end
@@ -171,7 +171,7 @@ local function force_detach(player)
 					lib_mount.passengers[player] = nil
 
 					-- Legacy support
-					copy_a_passenger_to_old_api(entity,i,true,false,false)
+					old_copy_passenger(entity,i,true,false,false)
 
 					break -- No need to continue looping. We found them.
 				end
@@ -241,7 +241,7 @@ function lib_mount.attach(entity, player, is_passenger, passenger_number)
 		lib_mount.passengers[player] = player
 
 		-- Legacy support
-		copy_a_passenger_to_old_api(entity,passenger_number,true,attach_updated,eye_updated)
+		old_copy_passenger(entity,passenger_number,true,attach_updated,eye_updated)
 	else
 		if not entity.driver_attach_at then
 			entity.driver_attach_at = {x=0, y=0, z=0}
@@ -287,7 +287,7 @@ function lib_mount.drive(entity, dtime, is_mob, moving_anim, stand_anim, jump_he
 		if passenger.player and not passenger.player:get_attach() then
 			entity.passengers[i].player = nil
 			-- Legacy support
-			copy_a_passenger_to_old_api(entity,i,true,false,false)
+			old_copy_passenger(entity,i,true,false,false)
 		end
 	end
 

--- a/init.lua
+++ b/init.lua
@@ -82,9 +82,9 @@ local function ensure_passengers_exists(entity)
 		return
 	end
 	entity.passengers = {}
-	if (not(entity.passenger == nil)) or
-		(not(entity.passenger_attach_at == nil)) or
-		(not(entity.passenger_eye_offset == nil)) then
+	if entity.passenger ~= nil or
+		entity.passenger_attach_at ~= nil or
+		entity.passenger_eye_offset ~= nil then
 		table.insert(entity.passengers,{
 			player=entity.passenger,
 			attach_at=entity.passenger_attach_at,
@@ -93,9 +93,9 @@ local function ensure_passengers_exists(entity)
 	else
 		return
 	end
-	if (not(entity.passenger2 == nil)) or
-		(not(entity.passenger2_attach_at == nil)) or
-		(not(entity.passenger2_eye_offset == nil)) then
+	if entity.passenger2 ~= nil or
+		entity.passenger2_attach_at ~= nil or
+		entity.passenger2_eye_offset ~= nil then
 		table.insert(entity.passengers,{
 			player=entity.passenger2,
 			attach_at=entity.passenger2_attach_at,
@@ -104,9 +104,9 @@ local function ensure_passengers_exists(entity)
 	else
 		return
 	end
-	if (not(entity.passenger3 == nil)) or
-		(not(entity.passenger3_attach_at == nil)) or
-		(not(entity.passenger3_eye_offset == nil)) then
+	if entity.passenger3 ~= nil or
+		entity.passenger3_attach_at ~= nil or
+		entity.passenger3_eye_offset ~= nil then
 		table.insert(entity.passengers,{
 			player=entity.passenger3,
 			attach_at=entity.passenger3_attach_at,

--- a/init.lua
+++ b/init.lua
@@ -112,7 +112,12 @@ end
 -- Copies the specified passenger to the older api. Note that this is one-directional.
 -- If something changed in the old api before this is called it is lost.
 -- In code you control be sure to always use the newer API and to call this function on every change.
+-- If you would like to improove preformance (memory & CPU) by not updating the old API, set
+--  entity.dont_use_old_passenger_api to true. This will return from the funciton instead of doing anything.
 local function copy_a_passenger_to_old_api(entity,index,player,attach,eye)
+	if entity.dont_use_old_passenger_api then
+		return
+	end
 	ensure_passengers_exists(entity)
 	if index==1 then  -- Don't forget! Lua indexes start at 1
 		if player then

--- a/init.lua
+++ b/init.lua
@@ -78,35 +78,40 @@ local function get_v(v)
 end
 
 local function ensure_passengers_exists(entity)
-	if entity.passengers == nil then
-		entity.passengers = {}
-		if (not(entity.passenger == nil)) or
-			(not(entity.passenger_attach_at == nil)) or
-			(not(entity.passenger_eye_offset == nil)) then
-			table.insert(entity.passengers,{
-				player=entity.passenger,
-				attach_at=entity.passenger_attach_at,
-				eye_offset=entity.passenger_eye_offset
-			})
-			if (not(entity.passenger2 == nil)) or
-				(not(entity.passenger2_attach_at == nil)) or
-				(not(entity.passenger2_eye_offset == nil)) then
-				table.insert(entity.passengers,{
-					player=entity.passenger2,
-					attach_at=entity.passenger2_attach_at,
-					eye_offset=entity.passenger2_eye_offset
-				})
-				if (not(entity.passenger3 == nil)) or
-					(not(entity.passenger3_attach_at == nil)) or
-					(not(entity.passenger3_eye_offset == nil)) then
-					table.insert(entity.passengers,{
-						player=entity.passenger3,
-						attach_at=entity.passenger3_attach_at,
-						eye_offset=entity.passenger3_eye_offset
-					})
-				end
-			end
-		end
+	if entity.passengers ~= nil then
+		return
+	end
+	entity.passengers = {}
+	if (not(entity.passenger == nil)) or
+		(not(entity.passenger_attach_at == nil)) or
+		(not(entity.passenger_eye_offset == nil)) then
+		table.insert(entity.passengers,{
+			player=entity.passenger,
+			attach_at=entity.passenger_attach_at,
+			eye_offset=entity.passenger_eye_offset
+		})
+	else
+		return
+	end
+	if (not(entity.passenger2 == nil)) or
+		(not(entity.passenger2_attach_at == nil)) or
+		(not(entity.passenger2_eye_offset == nil)) then
+		table.insert(entity.passengers,{
+			player=entity.passenger2,
+			attach_at=entity.passenger2_attach_at,
+			eye_offset=entity.passenger2_eye_offset
+		})
+	else
+		return
+	end
+	if (not(entity.passenger3 == nil)) or
+		(not(entity.passenger3_attach_at == nil)) or
+		(not(entity.passenger3_eye_offset == nil)) then
+		table.insert(entity.passengers,{
+			player=entity.passenger3,
+			attach_at=entity.passenger3_attach_at,
+			eye_offset=entity.passenger3_eye_offset
+		})
 	end
 end
 -- Copies the specified passenger to the older api. Note that this is one-directional.

--- a/init.lua
+++ b/init.lua
@@ -77,21 +77,84 @@ local function get_v(v)
 	return math.sqrt(v.x ^ 2 + v.z ^ 2)
 end
 
+local function ensure_passengers_exists(entity)
+	if entity.passengers == nil then  -- Does this properly handle an empty list?
+		entity.passengers={
+			{
+				player=entity.passenger,
+				attach_at=entity.passenger_attach_at
+				eye_offset=entity.passenger_eye_offset
+			},
+			{
+				player=entity.passenger2,
+				attach_at=entity.passenger2_attach_at
+				eye_offset=entity.passenger2_eye_offset
+			},
+			{
+				player=entity.passenger3,
+				attach_at=entity.passenger3_attach_at
+				eye_offset=entity.passenger3_eye_offset
+			},
+		}
+	then
+end
+-- Copies the specified passenger to the older api. Note that this is one-directional.
+-- If something changed in the old api before this is called it is lost.
+-- In code you control be sure to always use the newer API and to call this function on every change.
+local function copy_a_passenger_to_old_api(entity,index,player,attach,eye)
+	ensure_passengers_exists(entity)
+	if index==1 then  -- Don't forget! Lua indexes start at 1
+		if player then
+			entity.passenger = entity.passenger[index].player
+		end
+		if attach then
+			entity.passenger_attach_at = entity.passenger[index].attach_at
+		end
+		if eye then
+			entity.passenger_eye_offset = entity.passenger[index].eye_offset
+		end
+	elseif index==2 then
+		if player then
+			entity.passenger2 = entity.passenger[index].player
+		end
+		if attach then
+			entity.passenger2_attach_at = entity.passenger[index].attach_at
+		end
+		if eye then
+			entity.passenger2_eye_offset = entity.passenger[index].eye_offset
+		end
+	elseif index==3 then
+		if player then
+			entity.passenger3 = entity.passenger[index].player
+		end
+		if attach then
+			entity.passenger3_attach_at = entity.passenger[index].attach_at
+		end
+		if eye then
+			entity.passenger3_eye_offset = entity.passenger[index].eye_offset
+		end
+	end
+end
+
 local function force_detach(player)
 	local attached_to = player:get_attach()
 	if attached_to then
 		local entity = attached_to:get_luaentity()
 		if entity.driver and entity.driver == player then
 			entity.driver = nil
-		elseif entity.passenger and entity.passenger == player then
-			entity.passenger = nil
-			lib_mount.passengers[player] = nil
-		elseif entity.passenger2 and entity.passenger2 == player then
-			entity.passenger2 = nil
-			lib_mount.passengers[player] = nil
-		elseif entity.passenger3 and entity.passenger3 == player then
-			entity.passenger3 = nil
-			lib_mount.passengers[player] = nil
+		else
+			ensure_passengers_exists(entity)
+			for i,passenger in ipairs(entity.passengers) then
+				if passenger.player == player then -- If it's nil it won't match
+					entity.passengers[i].player = nil -- This maintains the behavior where you could have passenger 1 leave but passenger 2 is still there, and they don't move
+					lib_mount.passengers[player] = nil
+
+					-- Legacy support
+					copy_a_passenger_to_old_api(entity,i,true,false,false)
+
+					break -- No need to continue looping. We found them.
+				end
+			end
 		end
 		player:set_detach()
 		player_api.player_attached[player:get_player_name()] = false
@@ -135,47 +198,29 @@ function lib_mount.attach(entity, player, is_passenger, passenger_number)
 		rot_view = math.pi/2
 	end
 
-	if is_passenger == true and passenger_number == 1 then
-		if not entity.passenger_attach_at then
-			entity.passenger_attach_at = {x=0, y=0, z=0}
-		end
-		if not entity.passenger_eye_offset then
-			entity.passenger_eye_offset = {x=0, y=0, z=0}
-		end
+	if is_passenger == true then
+		-- Legacy support
+		ensure_passengers_exists(entity)
 
-		attach_at = entity.passenger_attach_at
-		eye_offset = entity.passenger_eye_offset
-
-		entity.passenger = player
-		lib_mount.passengers[entity.passenger] = player
-
-	elseif is_passenger == true and passenger_number == 2 then
-		if not entity.passenger2_attach_at then
-			entity.passenger2_attach_at = {x=0, y=0, z=0}
+		attach_updated=false
+		if not entity.passengers[passenger_number].attach_at then
+			entity.passengers[passenger_number].attach_at = {x=0, y=0, z=0}
+			attach_updated=true
 		end
-		if not entity.passenger2_eye_offset then
-			entity.passenger2_eye_offset = {x=0, y=0, z=0}
+		eye_updated=false
+		if not entity.passengers[passenger_number].eye_offset then
+			entity.passengers[passenger_number].eye_offset = {x=0, y=0, z=0}
+			eye_updated=true
 		end
 
-		attach_at = entity.passenger2_attach_at
-		eye_offset = entity.passenger2_eye_offset
+		attach_at = entity.passengers[passenger_number].attach_at
+		eye_offset = entity.passengers[passenger_number].eye_offset
 
-		entity.passenger2 = player
-		lib_mount.passengers[entity.passenger2] = player
+		entity.passengers[passenger_number].player = player
+		lib_mount.passengers[player] = player
 
-	elseif is_passenger == true and passenger_number == 3 then
-		if not entity.passenger3_attach_at then
-			entity.passenger3_attach_at = {x=0, y=0, z=0}
-		end
-		if not entity.passenger3_eye_offset then
-			entity.passenger3_eye_offset = {x=0, y=0, z=0}
-		end
-
-		attach_at = entity.passenger3_attach_at
-		eye_offset = entity.passenger3_eye_offset
-
-		entity.passenger3 = player
-		lib_mount.passengers[entity.passenger3] = player
+		-- Legacy support
+		copy_a_passenger_to_old_api(entity,passenger_number,true,attach_updated,eye_updated)
 	else
 		if not entity.driver_attach_at then
 			entity.driver_attach_at = {x=0, y=0, z=0}
@@ -215,14 +260,14 @@ function lib_mount.drive(entity, dtime, is_mob, moving_anim, stand_anim, jump_he
 	-- Sanity checks
 	if entity.driver and not entity.driver:get_attach() then entity.driver = nil end
 
-	if entity.passenger and not entity.passenger:get_attach() then
-		entity.passenger = nil
-	end
-	if entity.passenger2 and not entity.passenger2:get_attach() then
-		entity.passenger2 = nil
-	end
-	if entity.passenger3 and not entity.passenger3:get_attach() then
-		entity.passenger3 = nil
+	-- Legacy support
+	ensure_passengers_exists(entity)
+	for i,passenger in ipairs(entity.passengers) then
+		if passenger.player and not passenger.player:get_attach() then
+			entity.passengers[i].player = nil
+			-- Legacy support
+			copy_a_passenger_to_old_api(entity,i,true,false,false)
+		end
 	end
 
 	aux_timer = aux_timer + dtime
@@ -423,26 +468,15 @@ function lib_mount.drive(entity, dtime, is_mob, moving_anim, stand_anim, jump_he
 					drvr:set_velocity(new_velo)
 					drvr:set_hp(drvr:get_hp() - intensity)
 				end
-
-				if entity.passenger then
-					local pass = entity.passenger
-					lib_mount.detach(pass, {x=0, y=0, z=0})
-					pass:set_velocity(new_velo)
-					pass:set_hp(pass:get_hp() - intensity)
-				end
-
-				if entity.passenger2 then
-					local pass = entity.passenger2
-					lib_mount.detach(pass, {x=0, y=0, z=0})
-					pass:set_velocity(new_velo)
-					pass:set_hp(pass:get_hp() - intensity)
-				end
-
-				if entity.passenger3 then
-					local pass = entity.passenger3
-					lib_mount.detach(pass, {x=0, y=0, z=0})
-					pass:set_velocity(new_velo)
-					pass:set_hp(pass:get_hp() - intensity)
+				
+				ensure_passengers_exists(entity)-- Legacy support
+				for i,passenger in ipairs(entity.passengers) then
+					if passenger.player then
+						local pass = passenger.player
+						lib_mount.detach(pass, {x=0, y=0, z=0})  -- This function already copies to old API
+						pass:set_velocity(new_velo)
+						pass:set_hp(pass:get_hp() - intensity)
+					end
 				end
 				local pos = entity.object:get_pos()
 

--- a/init.lua
+++ b/init.lua
@@ -78,25 +78,36 @@ local function get_v(v)
 end
 
 local function ensure_passengers_exists(entity)
-	if entity.passengers == nil then  -- Does this properly handle an empty list?
-		entity.passengers={
-			{
+	if entity.passengers == nil then
+		entity.passengers = {}
+		if (not(entity.passenger == nil)) or
+			(not(entity.passenger_attach_at == nil)) or
+			(not(entity.passenger_eye_offset == nil)) then
+			table.insert(entity.passengers,{
 				player=entity.passenger,
-				attach_at=entity.passenger_attach_at
+				attach_at=entity.passenger_attach_at,
 				eye_offset=entity.passenger_eye_offset
-			},
-			{
-				player=entity.passenger2,
-				attach_at=entity.passenger2_attach_at
-				eye_offset=entity.passenger2_eye_offset
-			},
-			{
-				player=entity.passenger3,
-				attach_at=entity.passenger3_attach_at
-				eye_offset=entity.passenger3_eye_offset
-			},
-		}
-	then
+			})
+			if (not(entity.passenger2 == nil)) or
+				(not(entity.passenger2_attach_at == nil)) or
+				(not(entity.passenger2_eye_offset == nil)) then
+				table.insert(entity.passengers,{
+					player=entity.passenger2,
+					attach_at=entity.passenger2_attach_at,
+					eye_offset=entity.passenger2_eye_offset
+				})
+				if (not(entity.passenger3 == nil)) or
+					(not(entity.passenger3_attach_at == nil)) or
+					(not(entity.passenger3_eye_offset == nil)) then
+					table.insert(entity.passengers,{
+						player=entity.passenger3,
+						attach_at=entity.passenger3_attach_at,
+						eye_offset=entity.passenger3_eye_offset
+					})
+				end
+			end
+		end
+	end
 end
 -- Copies the specified passenger to the older api. Note that this is one-directional.
 -- If something changed in the old api before this is called it is lost.
@@ -105,33 +116,33 @@ local function copy_a_passenger_to_old_api(entity,index,player,attach,eye)
 	ensure_passengers_exists(entity)
 	if index==1 then  -- Don't forget! Lua indexes start at 1
 		if player then
-			entity.passenger = entity.passenger[index].player
+			entity.passenger = entity.passengers[index].player
 		end
 		if attach then
-			entity.passenger_attach_at = entity.passenger[index].attach_at
+			entity.passenger_attach_at = entity.passengers[index].attach_at
 		end
 		if eye then
-			entity.passenger_eye_offset = entity.passenger[index].eye_offset
+			entity.passenger_eye_offset = entity.passengers[index].eye_offset
 		end
 	elseif index==2 then
 		if player then
-			entity.passenger2 = entity.passenger[index].player
+			entity.passenger2 = entity.passengers[index].player
 		end
 		if attach then
-			entity.passenger2_attach_at = entity.passenger[index].attach_at
+			entity.passenger2_attach_at = entity.passengers[index].attach_at
 		end
 		if eye then
-			entity.passenger2_eye_offset = entity.passenger[index].eye_offset
+			entity.passenger2_eye_offset = entity.passengers[index].eye_offset
 		end
 	elseif index==3 then
 		if player then
-			entity.passenger3 = entity.passenger[index].player
+			entity.passenger3 = entity.passengers[index].player
 		end
 		if attach then
-			entity.passenger3_attach_at = entity.passenger[index].attach_at
+			entity.passenger3_attach_at = entity.passengers[index].attach_at
 		end
 		if eye then
-			entity.passenger3_eye_offset = entity.passenger[index].eye_offset
+			entity.passenger3_eye_offset = entity.passengers[index].eye_offset
 		end
 	end
 end
@@ -144,7 +155,7 @@ local function force_detach(player)
 			entity.driver = nil
 		else
 			ensure_passengers_exists(entity)
-			for i,passenger in ipairs(entity.passengers) then
+			for i,passenger in ipairs(entity.passengers) do
 				if passenger.player == player then -- If it's nil it won't match
 					entity.passengers[i].player = nil -- This maintains the behavior where you could have passenger 1 leave but passenger 2 is still there, and they don't move
 					lib_mount.passengers[player] = nil
@@ -202,12 +213,12 @@ function lib_mount.attach(entity, player, is_passenger, passenger_number)
 		-- Legacy support
 		ensure_passengers_exists(entity)
 
-		attach_updated=false
+		local attach_updated=false
 		if not entity.passengers[passenger_number].attach_at then
 			entity.passengers[passenger_number].attach_at = {x=0, y=0, z=0}
 			attach_updated=true
 		end
-		eye_updated=false
+		local eye_updated=false
 		if not entity.passengers[passenger_number].eye_offset then
 			entity.passengers[passenger_number].eye_offset = {x=0, y=0, z=0}
 			eye_updated=true
@@ -262,7 +273,7 @@ function lib_mount.drive(entity, dtime, is_mob, moving_anim, stand_anim, jump_he
 
 	-- Legacy support
 	ensure_passengers_exists(entity)
-	for i,passenger in ipairs(entity.passengers) then
+	for i,passenger in ipairs(entity.passengers) do
 		if passenger.player and not passenger.player:get_attach() then
 			entity.passengers[i].player = nil
 			-- Legacy support
@@ -470,7 +481,7 @@ function lib_mount.drive(entity, dtime, is_mob, moving_anim, stand_anim, jump_he
 				end
 				
 				ensure_passengers_exists(entity)-- Legacy support
-				for i,passenger in ipairs(entity.passengers) then
+				for _,passenger in ipairs(entity.passengers) do
 					if passenger.player then
 						local pass = passenger.player
 						lib_mount.detach(pass, {x=0, y=0, z=0})  -- This function already copies to old API

--- a/init.lua
+++ b/init.lua
@@ -479,7 +479,6 @@ function lib_mount.drive(entity, dtime, is_mob, moving_anim, stand_anim, jump_he
 					drvr:set_velocity(new_velo)
 					drvr:set_hp(drvr:get_hp() - intensity)
 				end
-				
 				ensure_passengers_exists(entity)-- Legacy support
 				for _,passenger in ipairs(entity.passengers) do
 					if passenger.player then

--- a/init.lua
+++ b/init.lua
@@ -118,9 +118,9 @@ end
 -- If something changed in the old api before this is called it is lost.
 -- In code you control be sure to always use the newer API and to call this function on every change.
 -- If you would like to improove preformance (memory & CPU) by not updating the old API, set
---  entity.dont_use_old_passenger_api to true. This will return from the funciton instead of doing anything.
+--  entity.new_api to true. This will return from the funciton instead of doing anything.
 local function old_copy_passenger(entity,index,player,attach,eye)
-	if entity.dont_use_old_passenger_api then
+	if entity.new_api then
 		return
 	end
 	ensure_passengers_exists(entity)


### PR DESCRIPTION
In the future someone may wish to make a mod that has more than just 3 passengers - such as a 8 seat SUV or caravan or even something like a school-bus or a jet airliner.

This change allows reasonable backwards compatibility with any mods that depend on this under the assumption that they don't directly modify certain variables - `vehicle_mash` (the only mod I can find that does use `lib_mount`) doesn't modify these. It does read them, and this PR supports that.

I've done _some_ testing, but it's hard to test on my own. Seems to work.

## Other things I'd like to fix that depend on on this PR

- move vehicle_mash to the new API in a backwards-compatible way. (code written)
- moves the vehicles in vehicle_mash to the new API (with performance flag set) (code not written)
- fix that API hole (code not written)