### PR TITLE
amend load print

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -522,10 +522,10 @@ function lib_mount.drive(entity, dtime, is_mob, moving_anim, stand_anim, jump_he
 	entity.v2 = v
 end
 
--- print to log after mod was loaded successfully
-local load_message = "[MOD] Library Mount loaded"
+-- Print after the mod was loaded successfully
+local load_message = "[MOD] Library Mount loaded!"
 if minetest.log then
-	minetest.log("info", load_message) -- aims at state of the art MT software
+	minetest.log("info", load_message) -- Aims at state of the MT software art
 else
-	print (load_message)  -- aims at legacy MT software used in the field
+	print(load_message)  -- Aims at legacy MT software used in the field
 end

--- a/init.lua
+++ b/init.lua
@@ -521,3 +521,6 @@ function lib_mount.drive(entity, dtime, is_mob, moving_anim, stand_anim, jump_he
 
 	entity.v2 = v
 end
+
+-- print to log after mod was loaded successfully
+print ("[MOD] Library Mount loaded")

--- a/init.lua
+++ b/init.lua
@@ -523,4 +523,9 @@ function lib_mount.drive(entity, dtime, is_mob, moving_anim, stand_anim, jump_he
 end
 
 -- print to log after mod was loaded successfully
-print ("[MOD] Library Mount loaded")
+local load-message = "[MOD] Library Mount loaded"
+if minetest.log then
+	minetest.log("info", load-message)
+else
+	print (load-message)  -- aims at legacy MT software used in the field
+end

--- a/init.lua
+++ b/init.lua
@@ -523,9 +523,9 @@ function lib_mount.drive(entity, dtime, is_mob, moving_anim, stand_anim, jump_he
 end
 
 -- print to log after mod was loaded successfully
-local load-message = "[MOD] Library Mount loaded"
+local load_message = "[MOD] Library Mount loaded"
 if minetest.log then
-	minetest.log("info", load-message)
+	minetest.log("info", load_message) -- aims at state of the art MT software
 else
-	print (load-message)  -- aims at legacy MT software used in the field
+	print (load_message)  -- aims at legacy MT software used in the field
 end


### PR DESCRIPTION
Add a final **print to log** at the end of `init.lua` to indicate the mod was loaded successfully. This idea was derived from other mods which are specifically aimed at MT servers.

This could be useful not only for player support (e.g. in the MT forum) but would certainly be useful for MT server admins using the CLI and reading their server logs.