### PR TITLE
Limit mouselook turn speed

### DIFF
--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,0 +1,1 @@
+lib_mount.limited_turn_speed (If enabled, mouselook speed will be limited to the entity's given value) bool false


### PR DESCRIPTION
Things added/changed:

- Limit mouselook turn speed.
  - This will make it more realistic as well similar to the WASD turn speed. Can be enabled and disabled at any time.
