### PR TITLE
fix player horizontal look rotation on attach

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -257,7 +257,7 @@ function lib_mount.attach(entity, player, is_passenger, passenger_number)
 	minetest.after(0.2, function()
 		player_api.set_animation(player, "sit", 30)
 	end)
-	player:set_look_horizontal(entity.object:get_yaw() + math.rad(entity.player_rotation.y or 90))
+	player:set_look_horizontal(entity.object:get_yaw() - math.rad(entity.player_rotation.y or 90))
 end
 
 function lib_mount.detach(player, offset)


### PR DESCRIPTION
If vehicle `player_rotation.y` is not zero, the view must be rotated in the  opposite way from the attachment rotation.

I'm actually not sure why? Seems like world rotation positive direction is opposite of attachment rotation (model rotations?).

To see what this change fixes, take `vehicle_mash:car_nyan_ride` and sit in it - you will be rotated 180 degrees backwards. Same with the hovercrafts, both vehicles have `player_rotation` set to (0,90,0).